### PR TITLE
Removed "file_denylist": ""

### DIFF
--- a/egg/egg-s-c-p--s-l--global.json
+++ b/egg/egg-s-c-p--s-l--global.json
@@ -12,7 +12,6 @@
 	"images": [
 		"joker119\/scp_image:Global"
 	],
-	"file_denylist": "",
 	"startup": ".\/LocalAdmin {{SERVER_PORT}} -c -- -sharenonconfigs -configpath \/home\/container\/scp_server\/servers\/server1",
 	"config": {
 		"files": "{\r\n    \r\n}",


### PR DESCRIPTION
This leads to a bug that prevents pterodactyl from allowing people to import the egg. This was fixed in later versions, however by deleting the line, it fixes the problem. This glitch /solution can be found here: https://github.com/pterodactyl/panel/issues/3034.